### PR TITLE
Fixed compatability issue for android native client

### DIFF
--- a/hedwig-api/src/main/java/com/hs/mail/imap/dao/MySqlSearchDao.java
+++ b/hedwig-api/src/main/java/com/hs/mail/imap/dao/MySqlSearchDao.java
@@ -157,8 +157,9 @@ public class MySqlSearchDao extends AbstractDao implements SearchDao {
 		List<Long> result = new ArrayList<Long>();
 		SequenceRange[] sequenceSet = key.getSequenceSet();
 		for (int i = 0; i < sequenceSet.length; i++) {
-			long min = map.getMinMessageNumber(sequenceSet[i].getMin());
-			long max = map.getMaxMessageNumber(sequenceSet[i].getMax());
+			long min = sequenceSet[i].getMin();
+			long max = sequenceSet[i].getMax() > map.getUIDList().size()
+					? map.getUIDList().size() : sequenceSet[i].getMax();
 			for (long j = min; j <= max && j >= 0; j++) {
 				long messageID = map.getUID((int) j);
 				if (messageID != -1) {

--- a/hedwig-server/src/main/java/com/hs/mail/imap/processor/SearchProcessor.java
+++ b/hedwig-server/src/main/java/com/hs/mail/imap/processor/SearchProcessor.java
@@ -53,9 +53,13 @@ public class SearchProcessor extends AbstractImapProcessor {
 		if (CollectionUtils.isNotEmpty(results)) {
 			List<Long> searched = new ArrayList<Long>();
 			for (long messageID : results) {
-				long msgnum = map.getMessageNumber(messageID);
-				if (msgnum != -1) {
-					searched.add(msgnum);
+				if (request.isUseUID()) {
+					searched.add(messageID);
+				} else {
+					long msgnum = map.getMessageNumber(messageID);
+					if (msgnum != -1) {
+						searched.add(msgnum);
+					}
 				}
 			}
 			responder.untagged(request.getCommand() + " "


### PR DESCRIPTION
Based on RFC3501, UID section: https://tools.ietf.org/html/rfc3501#section-6.4.8, the UID SEARCH command takes MSN in sequence set, while return UID. The current implementation in hedwig assumes UID in sequence set, while tries to return MSN.

The pull request fixes this issue in two places. 

Firstly, In MySqlSearchDao.java, map.getMinMessageNumber method tries to convert UID to MSN, while the input is MSN, so we change that to use MSN directly. Note, this applies to regular SEARCH command too. 
Secondly, in SearchProcessor.java, we check whether this search request is from UID command. If so, we return message UID directly.